### PR TITLE
Load infertility data for clogit example

### DIFF
--- a/app.R
+++ b/app.R
@@ -82,7 +82,8 @@ server <- function(input, output, session) {
         } else if (identical(input$method, "clogit")) {
           if (!requireNamespace("survival", quietly = TRUE))
             validate("请先安装 survival 包：install.packages('survival')")
-          d <- survival::infert
+          data("infert", package = "survival")
+          d <- infert
           d$status <- as.integer(d$case)
           d$time <- 1
           d


### PR DESCRIPTION
## Summary
- ensure the `clogit` example loads the `infert` dataset from the survival package before assignment

## Testing
- `R -q -e "lintr::lint('app.R')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a59ceea498832b8196e8dac96a1ad5